### PR TITLE
fix order of operations bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.last_tmp.py

--- a/ps3/ps3a.py
+++ b/ps3/ps3a.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python3
 # 6.00 Problem Set 3A Solutions
 #
 # The 6.00 Word Game
@@ -8,7 +9,6 @@
 import random
 import string
 import os
-os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
 VOWELS = 'aeiou'
 CONSONANTS = 'bcdfghjklmnpqrstvwxyz'
@@ -33,7 +33,10 @@ def load_words():
     """
     print("Loading word list from file...")
     # inFile: file
-    inFile = open(WORDLIST_FILENAME, 'r', -1)
+
+    filedir = os.path.dirname(os.path.abspath(__file__))
+    filepath = os.path.join(filedir, WORDLIST_FILENAME)
+    inFile = open(filepath, 'r', -1)
     # wordlist: list of strings
     wordlist = []
     for line in inFile:
@@ -261,14 +264,14 @@ def play_game(word_list):
     """
     # TO DO...
 
-#
-# Build data structures used for entire session and play game
-#
-if __name__ == '__main__':
+def main():
+    """Build data structures used for entire session and play game
+    """
+
     word_list = load_words()
     play_game(word_list)
 
-    #Testing for issues with is_valid_word function, look here y2k
+    #Testing for issues with is_valid_word function
     testword = 'quail'
     print('Test word is', testword)
     print('The hand is:', hand)
@@ -279,3 +282,6 @@ if __name__ == '__main__':
     print(testword in word_list)
     print('Testing output of function...')
     print(is_valid_word(testword, hand, word_list))
+
+if __name__ == '__main__':
+    main()

--- a/ps3/ps3a.py
+++ b/ps3/ps3a.py
@@ -7,6 +7,8 @@
 
 import random
 import string
+import os
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
 VOWELS = 'aeiou'
 CONSONANTS = 'bcdfghjklmnpqrstvwxyz'
@@ -180,7 +182,7 @@ def is_valid_word(word, hand, word_list):
     # Check if the word can be made out of the hand
     # Let's make the word into a dict then use some subtract method...
     worddict = get_frequency_dict(word)
-    #print(worddict)
+    print(worddict)
     if set(worddict).issubset(set(hand)) and word in word_list:
         diffs = {}
         #print('Canary!')
@@ -266,14 +268,14 @@ if __name__ == '__main__':
     word_list = load_words()
     play_game(word_list)
 
-#Learning pull requests, hw help mr. zak
-#Testing for issues with is_valid_word function, look here y2k
-#testword = 'quail'
-#print('Test word is', testword)
-#print('The hand is:', hand)
-#print('Testing compound if statement from word check function...')
-#print(set(get_frequency_dict(testword)).issubset(set(hand)) and testword in word_list)
-#print('Testing boolean check for word in wordlist...')
-#print(testword in word_list)
-#print('Testing output of function...')
-#print(is_valid_word(testword, hand, word_list))
+    #Testing for issues with is_valid_word function, look here y2k
+    testword = 'quail'
+    print('Test word is', testword)
+    print('The hand is:', hand)
+    print('Testing compound if statement from word check function...')
+    print('exactly as is was before it was fixed above...')
+    print(set(get_frequency_dict(testword)).issubset(set(hand)) and testword in word_list == True)
+    print('Testing boolean check for word in wordlist...')
+    print(testword in word_list)
+    print('Testing output of function...')
+    print(is_valid_word(testword, hand, word_list))


### PR DESCRIPTION
I moved at test code to only run when run as script (as opposed to when imported). Also modified your test case to test what you had in the body. It was correctly evaluating your `if` block to `False`.

Did a hacky way to make make word list text file be visible no matter where you run script from. I was running on phone.

Added .gitignore file cause my editor was sitting in the repo. You can add ignores for vim and pyc files as well so it's easy to commit.